### PR TITLE
Fix generating private key with v24

### DIFF
--- a/gen-signet-keys.sh
+++ b/gen-signet-keys.sh
@@ -34,7 +34,8 @@ if [[ "$MINERENABLED" == "1" && ("$SIGNETCHALLENGE" == "" || "$PRIVKEY" == "") ]
     #wait a bit for startup
     sleep 5s
     #create wallet
-    $BITCOINCLI createwallet "temp"
+    # todo, redo to work with descriptors
+    $BITCOINCLI -named createwallet wallet_name="tmp" descriptors=false
     #export future signet seeding key data
     ADDR=$($BITCOINCLI getnewaddress)
     PRIVKEY=$($BITCOINCLI dumpprivkey $ADDR)


### PR DESCRIPTION
I couldn't get the signing to work with a descriptor wallet, think it might be an issuer with `miner` which seems to be a bitcoin core issue.

This however fixes so when you first try to create a signet that you are able to actually generate a key with v24